### PR TITLE
Clear apt cache and reduce layer count

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM ubuntu:bionic
 
-RUN apt-get update
-RUN apt-get install -y unzip curl libcurl4 libssl1.0.0
-RUN curl https://minecraft.azureedge.net/bin-linux/bedrock-server-1.16.220.02.zip --output bedrock-server.zip
-RUN unzip bedrock-server.zip -d bedrock-server
-RUN chmod +x bedrock-server/bedrock_server
-RUN rm bedrock-server.zip
+RUN apt-get update \
+ && apt-get install -y unzip curl libcurl4 libssl1.0.0 \
+ && apt-get clean 
+
+RUN curl https://minecraft.azureedge.net/bin-linux/bedrock-server-1.16.220.02.zip --output bedrock-server.zip \ 
+ && unzip bedrock-server.zip -d bedrock-server \
+ && chmod +x bedrock-server/bedrock_server \
+ && rm bedrock-server.zip
 
 WORKDIR /bedrock-server
 ENV LD_LIBRARY_PATH=.


### PR DESCRIPTION
This should help reduce the amount of layers in the image, reducing the image's size and hopefully reducing processing when you make the image.